### PR TITLE
Fix documentation for bootstrap (minor)

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1,7 +1,7 @@
 #' Generate \code{n} bootstrap replicates.
 #'
 #' @inheritParams resample_partition
-#' @param n Number of test-training pairs to generate
+#' @param n Number of bootstrap replicates to generate
 #' @param id Name of variable that gives each model a unique integer id.
 #' @return A data frame with \code{n} rows and one column: \code{strap}
 #' @export

--- a/man/bootstrap.Rd
+++ b/man/bootstrap.Rd
@@ -9,7 +9,7 @@ bootstrap(data, n, id = ".id")
 \arguments{
 \item{data}{A data frame}
 
-\item{n}{Number of test-training pairs to generate}
+\item{n}{Number of bootstrap replicates to generate}
 
 \item{id}{Name of variable that gives each model a unique integer id.}
 }
@@ -29,4 +29,3 @@ tidied <- map_df(models, broom::tidy, .id = "id")
 hist(subset(tidied, term == "wt")$estimate)
 hist(subset(tidied, term == "(Intercept)")$estimate)
 }
-


### PR DESCRIPTION
Bootstrap docs had language copied from cross-validation; it does not have test-training pairs.