### PR TITLE
Ignore README.Rmd in R build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.travis\.yml$
 ^data-raw$
 ^codecov\.yml$
+^README.Rmd$


### PR DESCRIPTION
Silence the R CMD check warning about nonstandard file found.