### PR TITLE
Default geom_ref_line colour to panel.grid.major

### DIFF
--- a/R/geom_ref_line.R
+++ b/R/geom_ref_line.R
@@ -4,7 +4,8 @@
 #' @param size Line size
 #' @param colour Line colour
 #' @export
-geom_ref_line <- function(h, v, size = 2, colour = "white") {
+geom_ref_line <- function(h, v, size = 2, 
+                          colour = ggplot2::theme_get()$panel.grid.major$colour) {
   if (!missing(h)) {
     ggplot2::geom_hline(yintercept = h, size = size, colour = colour)
   } else if (!missing(v)) {

--- a/man/geom_ref_line.Rd
+++ b/man/geom_ref_line.Rd
@@ -4,7 +4,7 @@
 \alias{geom_ref_line}
 \title{Add a reference line (ggplot2).}
 \usage{
-geom_ref_line(h, v, size = 2, colour = "white")
+geom_ref_line(h, v, size = 2, colour = ggplot2::theme_get()$panel.grid.major$colour)
 }
 \arguments{
 \item{h, v}{Position of horizontal or vertical reference line}


### PR DESCRIPTION
Use the current theme's panel.grid.major color for geom_ref_line, which seems to be better than defaulting to "white". 

I use this a lot with `theme_bw()`, and it's a bit annoying to specify `colour = "grey92"` everytime ...