### PR TITLE
add_residuals man: Mention the var argument

### DIFF
--- a/man/add_residuals.Rd
+++ b/man/add_residuals.Rd
@@ -15,8 +15,8 @@ gather_residuals(data, ..., .resid = "resid", .model = "model")
 \arguments{
 \item{data}{A data frame used to generate the residuals}
 
-\item{model, var}{\code{add_residuals} takes a single \code{model}; the
-output column will be called \code{resid}}
+\item{model, var}{\code{add_residuals} takes a single \code{model}; the output column name
+can be specified by setting \code{var}. If omitted, it will be called \code{resid}}
 
 \item{...}{\code{gather_residuals} and \code{spread_residuals} take
 multiple models. The name will be taken from either the argument


### PR DESCRIPTION
This clarifies that the column name is not hard coded to "resid" but can be specified.