### PR TITLE
add_predictions() supports further arguments to the underlying predict()

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/man/add_predictions.Rd
+++ b/man/add_predictions.Rd
@@ -6,7 +6,7 @@
 \alias{gather_predictions}
 \title{Add predictions to a data frame}
 \usage{
-add_predictions(data, model, var = "pred", type = NULL)
+add_predictions(data, model, var = "pred", type = NULL, ...)
 
 spread_predictions(data, ..., type = NULL)
 
@@ -24,7 +24,9 @@ gather_predictions(data, ..., .pred = "pred", .model = "model", type = NULL)
 
 \item{...}{\code{gather_predictions} and \code{spread_predictions} take
 multiple models. The name will be taken from either the argument
-name of the name of the model.}
+name of the name of the model. \code{add_predictions} passes further arguments
+to the underlying \code{predict} generic method; this allows, for example, to
+also get confidence or prediction bands (when available).}
 
 \item{.pred, .model}{The variable names used by \code{gather_predictions}.}
 }
@@ -48,6 +50,9 @@ plot(df)
 m1 <- lm(y ~ x, data = df)
 grid <- data.frame(x = seq(0, 1, length = 10))
 grid \%>\% add_predictions(m1)
+
+# To also get confidence bands:
+grid \%>\% add_predictions(m1, interval="confidence", level=0.99)
 
 m2 <- lm(y ~ poly(x, 2), data = df)
 grid \%>\% spread_predictions(m1, m2)

--- a/man/bootstrap.Rd
+++ b/man/bootstrap.Rd
@@ -31,8 +31,8 @@ hist(subset(tidied, term == "(Intercept)")$estimate)
 }
 \seealso{
 Other resampling techniques: 
+\code{\link{resample}()},
 \code{\link{resample_bootstrap}()},
-\code{\link{resample_partition}()},
-\code{\link{resample}()}
+\code{\link{resample_partition}()}
 }
 \concept{resampling techniques}

--- a/man/resample_bootstrap.Rd
+++ b/man/resample_bootstrap.Rd
@@ -20,7 +20,7 @@ coef(lm(mpg ~ wt, data = resample_bootstrap(mtcars)))
 \seealso{
 Other resampling techniques: 
 \code{\link{bootstrap}()},
-\code{\link{resample_partition}()},
-\code{\link{resample}()}
+\code{\link{resample}()},
+\code{\link{resample_partition}()}
 }
 \concept{resampling techniques}

--- a/man/resample_partition.Rd
+++ b/man/resample_partition.Rd
@@ -24,7 +24,7 @@ rmse(mod, ex$train)
 \seealso{
 Other resampling techniques: 
 \code{\link{bootstrap}()},
-\code{\link{resample_bootstrap}()},
-\code{\link{resample}()}
+\code{\link{resample}()},
+\code{\link{resample_bootstrap}()}
 }
 \concept{resampling techniques}

--- a/tests/testthat/test-predictions.R
+++ b/tests/testthat/test-predictions.R
@@ -27,4 +27,11 @@ test_that("*_predictions() return expected shapes", {
   expect_equal(nrow(out), nrow(df) * 2)
 })
 
+test_that("add_predictions() provide intervals", {
+  df <- tibble::tibble(x = 1:5, y = c(1, 4, 3, 2, 5))
+  mod <- lm(y ~ x, data = df)
+  pred <- stats::predict(mod, df, interval="conf")
 
+  out <- add_predictions(df, mod, interval = "confidence")
+  expect_equal(out$lwr, as.numeric(pred[,"lwr"]))
+})


### PR DESCRIPTION
This is a small change to `add_predictions()` so that it can add confidence or prediction bands as well:

```r
df %>% add_predictions(model, interval="confidence", level=0.99)
```

I have also updated the `actions/upload-artifact@v3` to `actions/upload-artifact@v5` in the GitHub action, since the former is deprecated.